### PR TITLE
Fix mobile horizontal scrollbar due to width

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -102,6 +102,11 @@
     body {
         @apply bg-background text-foreground;
     }
+
+    html, body {
+        overflow-x: hidden;
+        width: 100%;
+    }
 }
 
 .skeleton {


### PR DESCRIPTION
Add `overflow-x: hidden` and `width: 100%` to `html, body` to prevent horizontal scrollbars on mobile.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf8ea69a-8c54-4c63-8485-9630cfae40e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bf8ea69a-8c54-4c63-8485-9630cfae40e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

