### PR TITLE
Fix mobile chat width overflow

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -129,7 +129,7 @@ export function Chat({
 
   return (
     <>
-      <div className="flex flex-col min-w-0 h-dvh bg-background">
+      <div className="flex flex-col min-w-0 h-dvh bg-background overflow-x-hidden">
         <ChatHeader
           chatId={id}
           selectedModelId={initialChatModel}

--- a/components/suggested-actions.tsx
+++ b/components/suggested-actions.tsx
@@ -69,7 +69,7 @@ function PureSuggestedActions({
                 parts: [{ type: 'text', text: suggestedAction.action }],
               });
             }}
-            className="text-left border rounded-xl px-4 py-3.5 text-sm flex-1 gap-1 sm:flex-col w-full h-auto justify-start items-start"
+            className="text-left border rounded-xl px-4 py-3.5 text-sm flex-1 gap-1 sm:flex-col w-full h-auto justify-start items-start whitespace-normal break-words text-pretty"
           >
             <span className="font-medium">{suggestedAction.title}</span>
             <span className="text-muted-foreground">


### PR DESCRIPTION
Prevent horizontal scrollbar on mobile chat interface by allowing suggested action buttons to wrap and hiding container overflow.

---
<a href="https://cursor.com/background-agent?bcId=bc-968861ec-d08b-472b-a238-16f0fa975868">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-968861ec-d08b-472b-a238-16f0fa975868">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

