### PR TITLE
Truncate agent preview prompt for better layout

### DIFF
--- a/app/(chat)/agents/components/agent-prompt-card.tsx
+++ b/app/(chat)/agents/components/agent-prompt-card.tsx
@@ -15,13 +15,26 @@ import { toast } from 'sonner';
 interface AgentPromptCardProps {
   agentPrompt: string;
   showTitle?: boolean;
+  /** Number of lines to show when collapsed (defaults to 8) */
+  collapsedLines?: number;
+  /** Character length that triggers truncation (defaults to 500) */
+  longCharThreshold?: number;
+  /** Line count that triggers truncation (defaults to 8) */
+  longLineThreshold?: number;
 }
 
-export function AgentPromptCard({ agentPrompt, showTitle = true }: AgentPromptCardProps) {
+export function AgentPromptCard({
+  agentPrompt,
+  showTitle = true,
+  collapsedLines = 8,
+  longCharThreshold = 500,
+  longLineThreshold = 8,
+}: AgentPromptCardProps) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const isLong = agentPrompt.length > 500 || agentPrompt.split('\n').length > 8;
+  const totalLines = agentPrompt.split('\n');
+  const isLong = agentPrompt.length > longCharThreshold || totalLines.length > longLineThreshold;
   const displayText = !isExpanded && isLong
-    ? agentPrompt.split('\n').slice(0, 8).join('\n') + (agentPrompt.split('\n').length > 8 ? '\n...' : '...')
+    ? totalLines.slice(0, collapsedLines).join('\n') + (totalLines.length > collapsedLines ? '\n...' : '...')
     : agentPrompt;
 
   const copyToClipboard = async () => {

--- a/app/(chat)/agents/components/agent-quick-view.tsx
+++ b/app/(chat)/agents/components/agent-quick-view.tsx
@@ -46,7 +46,14 @@ export function AgentQuickView({ agent, open, onOpenChange }: AgentQuickViewProp
                 <h3 className="text-sm font-medium text-muted-foreground">
                   Agent Prompt
                 </h3>
-                <AgentPromptCard agentPrompt={agent.agentPrompt} showTitle={false} />
+                <AgentPromptCard
+                  agentPrompt={agent.agentPrompt}
+                  showTitle={false}
+                  /* Make preview more compact to avoid pushing CTA */
+                  collapsedLines={4}
+                  longCharThreshold={200}
+                  longLineThreshold={4}
+                />
               </div>
             )}
 


### PR DESCRIPTION
Increase truncation of agent prompt previews in the quick view dialog to keep the 'Start Chat' button visible.

---
<a href="https://cursor.com/background-agent?bcId=bc-a01b05ef-a83f-443c-bffa-ee7783c1d5f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a01b05ef-a83f-443c-bffa-ee7783c1d5f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

